### PR TITLE
Remove unnecessary renderCompleted call

### DIFF
--- a/js/ui/data_grid/ui.data_grid.grouping.js
+++ b/js/ui/data_grid/ui.data_grid.grouping.js
@@ -376,9 +376,11 @@ var GroupingHeaderPanelExtender = (function() {
 
         _appendGroupingItem: function(items) {
             var that = this,
+                isRendered = false,
                 groupPanelRenderedCallback = function(e) {
                     that._updateGroupPanelContent($(e.itemElement).find("." + DATAGRID_GROUP_PANEL_CLASS));
-                    that.renderCompleted.fire();
+                    isRendered && that.renderCompleted.fire();
+                    isRendered = true;
                 };
 
             if(that._isGroupPanelVisible()) {

--- a/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
+++ b/testing/tests/DevExpress.ui.widgets.dataGrid/dataGrid.tests.js
@@ -5336,7 +5336,13 @@ QUnit.test("Correct update group panel items runtime", function(assert) {
 
 QUnit.test("Check group panel items are draggable when toolbar items updated runtime", function(assert) {
     //arrange
+    var renderCompletedCallCount = 0;
     var dataGrid = $("#dataGrid").dxDataGrid({
+        onInitialized: function(e) {
+            e.component.getView("headerPanel").renderCompleted.add(function() {
+                renderCompletedCallCount++;
+            });
+        },
         columns: [{ dataField: "field1", groupIndex: 0 }, "field2"],
         groupPanel: { visible: true },
         dataSource: {
@@ -5354,6 +5360,7 @@ QUnit.test("Check group panel items are draggable when toolbar items updated run
     //assert
     var $groupPanelItems = $("#dataGrid").find(".dx-toolbar .dx-datagrid-drag-action");
     assert.equal($groupPanelItems.length, 1, "count of group panel items");
+    assert.equal(renderCompletedCallCount, 3, "renderCompleted call count");
 });
 
 //T113684


### PR DESCRIPTION
The firing of the renderCompleted event during the first render is not necessary because renderCompleted is fired automatically after the first view render.